### PR TITLE
Read streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-event-log",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Event log shared betweeen two peers with deterministic references",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`getState` uses a single readStream per core to fetch blocks.

This allows blocks to prefetched, making the most of the underlying hypercore performance.