### PR TITLE
Use a random id if none is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { Readable } = require('streamx')
+const sodium = require('sodium-universal')
 const Corestore = require('corestore')
 const debounceify = require('debounceify')
 const Accumulator = require('accumulator-hash')
@@ -7,10 +8,14 @@ module.exports = class OpLog extends Readable {
   constructor (id, opts) {
     super()
 
-    this.id = id
+    if (!id) {
+      const seed = Buffer.alloc(32)
+      sodium.randombytes_buf(seed)
+      id = seed.toString('hex')
+    }
 
     this.store = opts.store
-      ? opts.store.namespace('oplog' + this.id)
+      ? opts.store.namespace('oplog' + id)
       : new Corestore(opts.storage)
 
     this.local = this.store.get({ name: 'local' })

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "accumulator-hash": "^1.0.0",
     "corestore": "^6.0.1-alpha.9",
     "debounceify": "^1.0.0",
-    "sodium-native": "^3.3.0"
+    "sodium-universal": "^3.1.0"
   },
   "devDependencies": {
     "standard": "^16.0.4"


### PR DESCRIPTION
Use a random ID to prevent collisions between different logs with the same owner.